### PR TITLE
feat: add migration and seeder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jaslian/userupload",
     "description": "A console program that import CSV user data to the DB.",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "authors": [
         {
             "name": "Jason Lian",

--- a/src/config-phinx.php
+++ b/src/config-phinx.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+require_once 'Config/DbConfig.php';
+
+use App\Config\DbConfig;
+
+return [
+    'paths' => [
+        'migrations' => '/app/src/migrations',
+        'seeds' => '/app/src/seeds'
+    ],
+    'migration_base_class' => '\App\Migration\Migration',
+    'environments' => [
+        'default_migration_table' => 'phinxlog',
+        'default_database' => DbConfig::DB_NAME,
+        'dev' => [
+            'adapter' => DbConfig::DB_DEFAULT_DRIVER,
+            'host' => DbConfig::DB_HOST,
+            'name' => DbConfig::DB_NAME,
+            'user' => DbConfig::DB_USER,
+            'pass' => DbConfig::DB_PASSWORD,
+            'port' => DbConfig::DB_PORT,
+        ]
+    ]
+];

--- a/src/migrations/20210223144746_init_user_migration.php
+++ b/src/migrations/20210223144746_init_user_migration.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use App\Config\DbConfig;
+use App\Migration\Migration;
+use Illuminate\Database\Schema\Blueprint as Blueprint;
+
+/**
+ * Class InitUserMigration
+ */
+final class InitUserMigration extends Migration
+{
+    public function up(): void
+    {
+        $this->schema->dropIfExists(DbConfig::DB_USER_TABLE);
+        $this->schema->create(
+            DbConfig::DB_USER_TABLE,
+            function (Blueprint $table) {
+                // Auto-increment id
+                $table->increments('id');
+                $table->string('name');
+                $table->string('surname');
+                $table->string('email')->unique();
+                // Required for Eloquent's created_at and updated_at columns
+                $table->timestamps();
+            }
+        );
+    }
+
+    public function down(): void
+    {
+        $this->schema->drop(DbConfig::DB_USER_TABLE);
+    }
+}

--- a/src/seeds/UserSeeder.php
+++ b/src/seeds/UserSeeder.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use App\Config\DbConfig;
+use Phinx\Seed\AbstractSeed;
+use Faker\Factory;
+
+class UserSeeder extends AbstractSeed
+{
+    /**
+     * Run Method.
+     *
+     * Write your database seeder using this method.
+     *
+     * More information on writing seeders is available here:
+     * https://book.cakephp.org/phinx/0/en/seeding.html
+     */
+    public function run()
+    {
+        $data = [];
+        $faker = Factory::create();
+
+        for ($i = 0; $i < 100; $i++) {
+            $data[] = [
+                'name' => $faker->firstName(),
+                'surname' => $faker->lastName(),
+                'email' => $faker->email(),
+                'created_at' => date('Y-m-d H:i:s'),
+            ];
+        }
+
+        $users = $this->table(DbConfig::DB_USER_TABLE);
+        $users->insert($data)
+            ->saveData();
+    }
+}


### PR DESCRIPTION
- Add migration, run below command to start the migration, this will
  drop and recreate the `users` table.
  `php vendor/bin/phinx migrate -t 0 -e dev -c src/config-phinx.php`
- Add seeder, run below command to start the seeder, this will add
  dummy entries to the `users` table.